### PR TITLE
MacOS build fix for some machines

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -14,6 +14,7 @@ cmake(
         "BUILD_SHARED_LIBS": "OFF",
         "LIBUV_BUILD_TESTS": "OFF",
         "LIBUV_BUILD_BENCH": "OFF",
+        "CMAKE_SKIP_RPATH": "YES",
     },
     lib_source = ":all",
     out_static_libs = select({

--- a/README.md
+++ b/README.md
@@ -19,19 +19,19 @@ libuv_deps()
 Or ... to simplify others depending on ***your*** repository, add the following to your `repos.bzl`:
 
 ```bazel
-load("//3rdparty/bazel-rules-libuv:repos.bzl", libuv="repos")
+load("//3rdparty/bazel-rules-libuv:repos.bzl", libuv_repos="repos")
 
 def repos():
-    libuv()
+    libuv_repos()
 ```
 
 And the following to your `deps.bzl`:
 
 ```bazel
-load("@com_github_3rdparty_bazel_rules_libuv//bazel:deps.bzl", libuv="deps")
+load("@com_github_3rdparty_bazel_rules_libuv//bazel:deps.bzl", libuv_deps="deps")
 
 def deps():
-    libuv()
+    libuv_deps()
 ```
 
 4. You can then use `@com_github_libuv_libuv//:libuv` in your target's `deps`.
@@ -40,4 +40,4 @@ def deps():
 
 | libuv | Copy `bazel/repos.bzl` from: |
 | :---: | :--------------------------: |
-| 1.42.0 | [c672b03](https://github.com/3rdparty/bazel-rules-libuv/tree/c672b030143144dbda4cb5d2a83667972a24b79c) |
+| 1.42.0 | [71c98de](https://github.com/3rdparty/bazel-rules-libuv/tree/71c98def1562432a7776e5cbfff5c1a55374de2b) |

--- a/bazel/repos.bzl
+++ b/bazel/repos.bzl
@@ -10,22 +10,25 @@
 ########################################################################
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 def repos(external = True, repo_mapping = {}):
-    if "rules_foreign_cc" not in native.existing_rules():
-        http_archive(
-            name = "rules_foreign_cc",
-            url = "https://github.com/bazelbuild/rules_foreign_cc/archive/0.5.1.tar.gz",
-            sha256 = "33a5690733c5cc2ede39cb62ebf89e751f2448e27f20c8b2fbbc7d136b166804",
-            strip_prefix = "rules_foreign_cc-0.5.1",
-            repo_mapping = repo_mapping,
-        )
+    maybe(
+        http_archive,
+        name = "rules_foreign_cc",
+        url = "https://github.com/bazelbuild/rules_foreign_cc/archive/0.5.1.tar.gz",
+        sha256 = "33a5690733c5cc2ede39cb62ebf89e751f2448e27f20c8b2fbbc7d136b166804",
+        strip_prefix = "rules_foreign_cc-0.5.1",
+        repo_mapping = repo_mapping,
+    )
 
-    if external and "com_github_3rdparty_bazel_rules_libuv" not in native.existing_rules():
-        http_archive(
+    if external:
+        maybe(
+            git_repository,
             name = "com_github_3rdparty_bazel_rules_libuv",
-            url = "https://github.com/3rdparty/bazel-rules-libuv/archive/libuv-1.42.0.tar.gz",
-            sha256 = "dee419712e68412a804753208d2dfac055491578b860f1a6553c7d3395081c13",
-            strip_prefix = "bazel-rules-libuv-libuv-1.42.0",
+            remote = "https://github.com/3rdparty/bazel-rules-libuv",
+            commit = "171ca23e1f1c745f5ec98a36ff6369b7c4ab02c3",
+            shallow_since = "1631281455 +0000",
             repo_mapping = repo_mapping,
         )


### PR DESCRIPTION
MacOS VM has an issue with building libuv using RPATH. This PR uses a cmake workaround to build it successfully.

Don't forget to update sha256 in stout-eventuals after adding the new release archive!